### PR TITLE
Vermeide Leerraum unter "Lightning Talks"

### DIFF
--- a/etc/html_tmpl/programme.md.tmpl
+++ b/etc/html_tmpl/programme.md.tmpl
@@ -30,8 +30,10 @@ pagetitle: <tmpl_var swib> Programme
 
 #### <tmpl_var abstract_title>
 
+<tmpl_if authors_loop>
 <tmpl_loop authors_loop><tmpl_if author_id>[</tmpl_if><tmpl_var name><tmpl_if author_id>](speakers.html#<tmpl_var author_id>)</tmpl_if><tmpl_if orcid> [<img src="images/orcid.png" title="ORCID: <tmpl_var orcid>">](https://orcid.org/<tmpl_var orcid>)</tmpl_if><tmpl_if index><sup><tmpl_var index></sup></tmpl_if><tmpl_unless __last__>, </tmpl_unless></tmpl_loop>\
 <tmpl_loop organisations_loop><tmpl_if index><sup><tmpl_var index> </sup></tmpl_if><tmpl_var name><tmpl_unless __last__>; </tmpl_unless></tmpl_loop>
+</tmpl_if>
 
 <tmpl_var abstract>
 

--- a/etc/html_tmpl/registration.md.tmpl
+++ b/etc/html_tmpl/registration.md.tmpl
@@ -10,7 +10,7 @@ Conference fee: 180€\
 Workshop fee: 70€ (optional, only bookable in combination with conference participation)\
 Conference Dinner: 39,50€ (optional, only bookable in combination with conference participation)
 
-<a href='https://eveeno.com/892008387' target='_blank' style='font-weight:bold>Register now »</a>
+<a href='https://eveeno.com/892008387' target='_blank' style='font-weight:bold'>Register now »</a>
 
 </div>
 


### PR DESCRIPTION
Hallo Adrian, hallo Phu,

dieser PR ist nicht eilig, sondern wenn grade mal Zeit ist. Die Änderung an programme.md.tmpl vermeidet, dass ein Zeilenumbruch (und damit ein leerer Absatz) zwischen Autoren und Organisationen ausgegeben wird, wenn es überhaupt keine AutorInnen gibt.

Es wäre gut, wenn sich einer von euch das Ergebnis nochmal anschaut, ob die Programmseite dadurch irgendwo zerschossen wird. Andere Seiten sollten sich nicht ändern.

Schöne Grüße, Joachim